### PR TITLE
draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="userna
         Specific to SQL Alchemy; allows interaction with SQL Alchemy entities
         see https://docs.sqlalchemy.org/en/14/orm/session.html?highlight=session#module-sqlalchemy.orm.session
 
-    execute_query(self, query_string: str, args=None) -> list
+    execute_query(self, query_string: str, args: dict = None) -> list
         executes a sql query, return a list of dictionaries representing rows
+        'args' represents a dictionary of parameterized values for the query; see examples below
 
-    execute_update(self, query_string, args=None)
+    execute_update(self, query_string, args: dict = None)
         used to execute an insert, update, or delete sql statement
+        'args' represents a dictionary of parameterized values for the query; see examples below
     
     health_check()
         Performs a basic query against the db to ensure connectivity

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ In a suitable python3 (>=3.7) virtual env, using pip:
 * see https://github.com/huit/pylog for details
 
 ```    
-    db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
-    # where 8003 is a valid port
+db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
+# where 8003 is a valid port
 ```
 ## Basic operations
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ In a suitable python3 (>=3.7) virtual env, using pip:
 * logging_format is optional, and will default to pylog default formatting
 * see https://github.com/huit/pylog for details
 
-    
+```    
     db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
-    (where 8003 is a valid port)
-
+    # where 8003 is a valid port)
+```
 ## Basic operations
 
     create_connection()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ a tool for facilitating connection to databases with python and performing basic
 
 ## Purpose and intended audience 
 
-
+For many APIs the responses are based upon data residing in a relational database; this module provides a standardized
+way for python programmers to access a database, via straight SQL calls to `execute_query()` and `execute_update()` and 
+also permits users to access SQLAlchemy for ORM-based interactions with database objects.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 a tool for facilitating connection to databases with python and performing basic operations
 
+## Purpose and intended audience 
+
+
+
 ## Requirements
 
     python >= 3.7
@@ -10,11 +14,11 @@ a tool for facilitating connection to databases with python and performing basic
 ## Installation and setup
 
 In a suitable python3 (>=3.7) virtual env, using pip:
-
+```
     pip install https://github.com/huit/pydb/archive/v0.0.2.tar.gz#egg=pydb
     # import the module for the specific type of db you'd like to use
     from pydb.oracle_db import OracleDB
-
+```
 * creating an OracleDB instance requires host, port, service, user, pwd.
     * other db types may have other requirements - see specific module for details  
 * logging_level is optional, and will default to `logging.CRITICAL`
@@ -51,17 +55,32 @@ db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="userna
 Given a valid connection, and a table called `EMP`...
 
 To query the `EMP` table for all records:
-
+```
     result = db.execute_query("select * from emp")
-
+```
 To query the `EMP` table for a specific record:
-
+```
      result = db.execute_query("select * from emp where ename= :ename", {'ename':'JOHNSON'})
-
+```
 Results for the individual rows would be in the following form:
-
+```
     {'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
-
+```
 Row results may vary somewhat depending on the exact module... e.g., for SqlAlchemyOracleDB the following would be received:
-
+```
     {'empno': 7935, 'ename': 'JOHNSON', 'job': 'CLERK', 'mgr': 7839, 'hiredate': datetime.datetime(1981, 5, 1, 0, 0), 'sal': Decimal('2850'), 'comm': None, 'deptno': 30}
+```
+
+### integrated example
+```
+pip install https://github.com/huit/pydb/archive/v0.0.2.tar.gz#egg=pydb
+
+from pydb.oracle_db import OracleDB
+db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
+
+result = db.execute_query("select * from emp where ename= :ename", {'ename':'JOHNSON'})
+print(result)
+     
+{'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
+
+```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Results for the individual rows would be in the following form:
 
     {'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
 
-Row results may vary somewhat depending on the exact module... e.g., for SqlAlchemyOracleDB you would receive the following:
+Row results may vary somewhat depending on the exact module... e.g., for SqlAlchemyOracleDB the following would be received:
 
     {'empno': 7935, 'ename': 'JOHNSON', 'job': 'CLERK', 'mgr': 7839, 'hiredate': datetime.datetime(1981, 5, 1, 0, 0), 'sal': Decimal('2850'), 'comm': None, 'deptno': 30}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In a suitable python3 (>=3.7) virtual env, using pip:
 
 ```    
     db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
-    # where 8003 is a valid port)
+    # where 8003 is a valid port
 ```
 ## Basic operations
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ In a suitable python3 (>=3.7) virtual env, using pip:
 * see https://github.com/huit/pylog for details
 
     
-    # where 8003 is a valid port
     db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
+    # where 8003 is a valid port
 
 ## Basic operations
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In a suitable python3 (>=3.7) virtual env, using pip:
 
     
     db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
-    # where 8003 is a valid port
+    (where 8003 is a valid port)
 
 ## Basic operations
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # pydb
+
+a tool for facilitating connection to databases with python and performing basic operations
+
+## Requirements
+
+    python >= 3.7
+    (see setup.py for additional packages)
+
+## Installation and setup
+
+In a suitable python3 (>=3.7) virtual env, using pip:
+
+    pip install https://github.com/huit/pydb/archive/v0.0.2.tar.gz#egg=pydb
+    # import the module for the specific type of db you'd like to use
+    from pydb.oracle_db import OracleDB
+
+* creating an OracleDB instance requires host, port, service, user, pwd.
+    * other db types may have other requirements - see specific module for details  
+* logging_level is optional, and will default to `logging.CRITICAL`
+* logging_format is optional, and will default to pylog default formatting
+* see https://github.com/huit/pylog for details
+
+    
+    # where 8003 is a valid port
+    db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
+
+## Basic operations
+
+    create_connection()
+        provides a connection to the db host for more 'direct' access
+
+    get_session()
+        Specific to SQL Alchemy; allows interaction with SQL Alchemy entities
+        see https://docs.sqlalchemy.org/en/14/orm/session.html?highlight=session#module-sqlalchemy.orm.session
+
+    execute_query(self, query_string: str, args=None) -> list
+        executes a sql query, return a list of dictionaries representing rows
+
+    execute_update(self, query_string, args=None)
+        used to execute an insert, update, or delete sql statement
+    
+    health_check()
+        Performs a basic query against the db to ensure connectivity
+
+    cleanup()
+        Attempts to release any 'live' objects/connections to the host
+
+## Example
+
+Given a valid connection, and a table called `EMP`...
+
+To query the `EMP` table for all records:
+
+    result = db.execute_query("select * from emp")
+
+To query the `EMP` table for a specific record:
+
+     result = db.execute_query("select * from emp where ename= :ename", {'ename':'JOHNSON'})
+
+Results for the individual rows would be in the following form:
+
+    {'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
+
+Row results may vary somewhat depending on the exact module... e.g., for SqlAlchemyOracleDB you would receive the following:
+
+    {'empno': 7935, 'ename': 'JOHNSON', 'job': 'CLERK', 'mgr': 7839, 'hiredate': datetime.datetime(1981, 5, 1, 0, 0), 'sal': Decimal('2850'), 'comm': None, 'deptno': 30}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ a tool for facilitating connection to databases with python and performing basic
 
 In a suitable python3 (>=3.7) virtual env, using pip:
 ```
-    pip install https://github.com/huit/pydb/archive/v0.0.2.tar.gz#egg=pydb
+    pip install https://github.com/huit/pydb/archive/refs/tags/v0.0.2.tar.gz#egg=pydb
     # import the module for the specific type of db you'd like to use
     from pydb.oracle_db import OracleDB
 ```
@@ -56,31 +56,32 @@ Given a valid connection, and a table called `EMP`...
 
 To query the `EMP` table for all records:
 ```
-    result = db.execute_query("select * from emp")
+result = db.execute_query("select * from emp")
 ```
 To query the `EMP` table for a specific record:
 ```
-     result = db.execute_query("select * from emp where ename= :ename", {'ename':'JOHNSON'})
+result = db.execute_query("select * from emp where ename= :ename", {'ename':'JOHNSON'})
 ```
 Results for the individual rows would be in the following form:
 ```
-    {'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
+{'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
 ```
 Row results may vary somewhat depending on the exact module... e.g., for SqlAlchemyOracleDB the following would be received:
 ```
-    {'empno': 7935, 'ename': 'JOHNSON', 'job': 'CLERK', 'mgr': 7839, 'hiredate': datetime.datetime(1981, 5, 1, 0, 0), 'sal': Decimal('2850'), 'comm': None, 'deptno': 30}
+{'empno': 7935, 'ename': 'JOHNSON', 'job': 'CLERK', 'mgr': 7839, 'hiredate': datetime.datetime(1981, 5, 1, 0, 0), 'sal': Decimal('2850'), 'comm': None, 'deptno': 30}
 ```
 
 ### integrated example
 ```
-pip install https://github.com/huit/pydb/archive/v0.0.2.tar.gz#egg=pydb
+pip install https://github.com/huit/pydb/archive/refs/tags/v0.0.2.tar.gz#egg=pydb
 
 from pydb.oracle_db import OracleDB
 db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="username", pwd="pwd")
 
 result = db.execute_query("select * from emp where ename= :ename", {'ename':'JOHNSON'})
 print(result)
-     
+```
+produces
+```
 {'EMPNO': 7935, 'ENAME': 'JOHNSON', 'JOB': 'CLERK', 'MGR': 7839, 'HIREDATE': datetime.datetime(1981, 5, 1, 0, 0), 'SAL': 2850.0, 'COMM': None, 'DEPTNO': 30}
-
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="userna
     cleanup()
         Attempts to release any 'live' objects/connections to the host - to be run before exiting program
 
-## Example
+## Examples
 
 Given a valid connection, and a table called `EMP`...
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ db = OracleDb(host="valid_host", port=8003, service="SERVICE_NAME", user="userna
         Performs a basic query against the db to ensure connectivity
 
     cleanup()
-        Attempts to release any 'live' objects/connections to the host
+        Attempts to release any 'live' objects/connections to the host - to be run before exiting program
 
 ## Example
 

--- a/pydb/database.py
+++ b/pydb/database.py
@@ -12,21 +12,6 @@ class DatabaseType(Enum):
 
 
 class DBInterface(metaclass=abc.ABCMeta):
-    @classmethod
-    def __subclasshook__(cls, subclass):
-        return (hasattr(subclass, 'execute_query') and
-                callable(subclass.execute_query) and
-                hasattr(subclass, 'execute_update') and
-                callable(subclass.execute_update) and
-                hasattr(subclass, 'health_check') and
-                callable(subclass.health_check) and
-                hasattr(subclass, 'cleanup') and
-                callable(subclass.cleanup) and
-                hasattr(subclass, 'create_connection') and
-                callable(subclass.create_connection) and
-                hasattr(subclass, 'get_session') and
-                callable(subclass.get_session)
-                or NotImplemented)
 
         @abc.abstractmethod
         def execute_query(self, query_string: str, args=None) -> list:

--- a/pydb/database.py
+++ b/pydb/database.py
@@ -3,11 +3,12 @@ import abc
 from enum import Enum
 
 
-class Database(Enum):
+class DatabaseType(Enum):
     """
     not implemented: other databases
     """
     ORACLE = "oracle"
+    SQL_ALCHEMY_ORACLE = "sql_alchemy_oracle"
 
 
 class DBInterface(metaclass=abc.ABCMeta):
@@ -20,7 +21,12 @@ class DBInterface(metaclass=abc.ABCMeta):
                 hasattr(subclass, 'health_check') and
                 callable(subclass.health_check) and
                 hasattr(subclass, 'cleanup') and
-                callable(subclass.cleanup))
+                callable(subclass.cleanup) and
+                hasattr(subclass, 'create_connection') and
+                callable(subclass.create_connection) and
+                hasattr(subclass, 'get_session') and
+                callable(subclass.get_session)
+                or NotImplemented)
 
         @abc.abstractmethod
         def execute_query(self, query_string: str, args=None) -> dict:
@@ -36,4 +42,12 @@ class DBInterface(metaclass=abc.ABCMeta):
 
         @abc.abstractmethod
         def cleanup():
+            raise NotImplementedError
+
+        @abc.abstractmethod
+        def create_connection():
+            raise NotImplementedError
+
+        @abc.abstractmethod
+        def get_session():
             raise NotImplementedError

--- a/pydb/database.py
+++ b/pydb/database.py
@@ -29,25 +29,55 @@ class DBInterface(metaclass=abc.ABCMeta):
                 or NotImplemented)
 
         @abc.abstractmethod
-        def execute_query(self, query_string: str, args=None) -> dict:
+        def execute_query(self, query_string: str, args=None) -> list:
+            """
+            executes a sql query, return a list of dictionaries representing rows
+            :param self:
+            :param query_string:
+            :param args:
+            :return:
+            """
             raise NotImplementedError
 
         @abc.abstractmethod
         def execute_update(self, query_string, args=None):
+            """
+            used to execute an insert, update, or delete sql statement
+            :param self:
+            :param query_string:
+            :param args:
+            :return:
+            """
             raise NotImplementedError
 
         @abc.abstractmethod
         def health_check():
+            """
+            Performs a basic query against the db to ensure connectivity
+            :return:
+            """
             raise NotImplementedError
 
         @abc.abstractmethod
         def cleanup():
+            """
+            Attempts to release any 'live' objects/connections to the host
+            :return:
+            """
             raise NotImplementedError
 
         @abc.abstractmethod
         def create_connection():
+            """
+            provides a connection to the db host for more 'direct' access
+            :return:
+            """
             raise NotImplementedError
 
         @abc.abstractmethod
         def get_session():
+            """
+            Specific to SQL Alchemy; allows interaction with SQL Alchemy entities
+            :return:
+            """
             raise NotImplementedError

--- a/pydb/database.py
+++ b/pydb/database.py
@@ -18,7 +18,9 @@ class DBInterface(metaclass=abc.ABCMeta):
                 hasattr(subclass, 'execute_update') and
                 callable(subclass.execute_update) and
                 hasattr(subclass, 'health_check') and
-                callable(subclass.health_check))
+                callable(subclass.health_check) and
+                hasattr(subclass, 'cleanup') and
+                callable(subclass.cleanup))
 
         @abc.abstractmethod
         def execute_query(self, query_string: str, args=None) -> dict:
@@ -30,4 +32,8 @@ class DBInterface(metaclass=abc.ABCMeta):
 
         @abc.abstractmethod
         def health_check():
+            raise NotImplementedError
+
+        @abc.abstractmethod
+        def cleanup():
             raise NotImplementedError

--- a/pydb/database.py
+++ b/pydb/database.py
@@ -1,0 +1,33 @@
+import abc
+
+from enum import Enum
+
+
+class Database(Enum):
+    """
+    not implemented: other databases
+    """
+    ORACLE = "oracle"
+
+
+class DBInterface(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        return (hasattr(subclass, 'execute_query') and
+                callable(subclass.execute_query) and
+                hasattr(subclass, 'execute_update') and
+                callable(subclass.execute_update) and
+                hasattr(subclass, 'health_check') and
+                callable(subclass.health_check))
+
+        @abc.abstractmethod
+        def execute_query(self, query_string: str, args=None) -> dict:
+            raise NotImplementedError
+
+        @abc.abstractmethod
+        def execute_update(self, query_string, args=None):
+            raise NotImplementedError
+
+        @abc.abstractmethod
+        def health_check():
+            raise NotImplementedError

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -25,7 +25,8 @@ class OracleDB(DBInterface):
     Class for interacting with an oracle database
     """
 
-    def __init__(self, host: str, port: int, service: str, user: str, pwd: str, logging_level: int = 50, logging_format: logging.Formatter = None):
+    def __init__(self, host: str, port: int, service: str, user: str, pwd: str,
+                 logging_level: int = 50, logging_format: logging.Formatter = None):
         """
         Setup for oracle db connections. oracle_config must be a python dictionary with the following fields:
 
@@ -176,3 +177,6 @@ class OracleDB(DBInterface):
                 obj, = err.args
                 self.logger.error("Context:", obj.context)
                 self.logger.error("Message:", obj.message)
+
+    def get_session(self):
+        return None

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -15,10 +15,12 @@ import cx_Oracle
 
 from pylog.pylog import get_common_logger_for_module
 
+from .database import DBInterface
+
 # Local imports
 
 
-class OracleDB:
+class OracleDB(DBInterface):
     """
     Class for interacting with an oracle database
     """
@@ -152,3 +154,10 @@ class OracleDB:
         finally:
             cursor.close()
             self.get_session_pool().release(connection)
+
+    def health_check(self):
+        """
+        provides a means to verify DB connectivity with a simple query
+        :return:
+        """
+        return self.execute_query("SELECT 1 FROM DUAL")

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -25,34 +25,36 @@ class OracleDB(DBInterface):
     Class for interacting with an oracle database
     """
 
-    def __init__(self, oracle_config: dict, logging_level: int = 50, logging_format: logging.Formatter = None):
+    def __init__(self, host: str, port: int, service: str, user: str, pwd: str, logging_level: int = 50, logging_format: logging.Formatter = None):
         """
         Setup for oracle db connections. oracle_config must be a python dictionary with the following fields:
-        host
-        port
-        instance (service name)
-        user
-        pwd
 
-        :param oracle_config:
+        :param host:
+        :param port:
+        :param service:
+        :param user:
+        :param pwd:
+        :param logging_level:
+        :param logging_format:
         :param logging_level: defaults to logging.CRITICAL
         :param logging_format: defaults to None here, which translates to the pylog.get_commong_logging_format
         """
-        self.oracle_config = oracle_config
+
+        self.host = host
+        self.port = port
+        self.service = service
+        self.user = user
+        self.pwd = pwd
         self.pool = self.set_up_session_pool()
 
         self.logger = get_common_logger_for_module(module_name=__name__, level=logging_level, log_format=logging_format)
 
     def set_up_session_pool(self):
-        host = self.oracle_config.get('host')
-        port = self.oracle_config.get('port')
-        instance = self.oracle_config.get('instance')
-
         try:
-            dsn_str = cx_Oracle.makedsn(host, port, service_name=instance)
+            dsn_str = cx_Oracle.makedsn(self.host, self.port, service_name=self.instance)
             pool = cx_Oracle.SessionPool(
-                user=self.oracle_config.get('user'),
-                password=self.oracle_config.get('pwd'),
+                user=self.user,
+                password=self.pwd,
                 dsn=dsn_str,
                 min=2,
                 max=5,

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -51,7 +51,7 @@ class OracleDB(DBInterface):
 
     def set_up_session_pool(self):
         try:
-            dsn_str = cx_Oracle.makedsn(self.host, self.port, service_name=self.instance)
+            dsn_str = cx_Oracle.makedsn(self.host, self.port, service_name=self.service)
             pool = cx_Oracle.SessionPool(
                 user=self.user,
                 password=self.pwd,

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -21,7 +21,7 @@ class OracleDB:
     Class for interacting with an oracle database
     """
 
-    def __init__(self, oracle_config: dict, logging_formatter: logging.Formatter = None):
+    def __init__(self, oracle_config: dict, logging_format: logging.Formatter = None):
         """
         Setup for oracle db connections. oracle_config must be a python dictionary with the following fields:
         host
@@ -31,26 +31,29 @@ class OracleDB:
         pwd
 
         :param oracle_config:
-        :param logging_formatter:
+        :param logging_format:
         """
         self.oracle_config = oracle_config
         self.pool = self.get_session_pool()
 
-        self.logger = logging.getLogger(__name__)
+        self.logger = self.setup_logger(logging_format)
+
+    @staticmethod
+    def setup_logger(logging_format: logging.Formatter = None) -> logging.Logger:
+        logger = logging.getLogger(__name__)
         stream_handler = logging.StreamHandler()
         stream_handler.setLevel(logging.INFO)
 
-        if logging_formatter:
-            stream_handler.setFormatter(logging_formatter)
-        else:
-            stream_format = logging.Formatter(
+        if logging_format is None:
+            logging_format = logging.Formatter(
                 '{"log_level": "%(levelname)s", '
                 '"app_file_line": "%(name)s:%(lineno)d", '
                 '"message": %(message)s}'
             )
-            stream_handler.setFormatter(stream_format)
-        self.logger.addHandler(stream_handler)
-        self.logger.setLevel(logging.INFO)
+        stream_handler.setFormatter(logging_format)
+        logger.addHandler(stream_handler)
+        logger.setLevel(logging.INFO)
+        return logger
 
     def get_session_pool(self):
         """

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -46,9 +46,10 @@ class OracleDB(DBInterface):
         self.service = service
         self.user = user
         self.pwd = pwd
+        self.logger = get_common_logger_for_module(module_name=__name__, level=logging_level, log_format=logging_format)
+
         self.pool = self.set_up_session_pool()
 
-        self.logger = get_common_logger_for_module(module_name=__name__, level=logging_level, log_format=logging_format)
 
     def set_up_session_pool(self):
         try:

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Module for interacting with the database
+Module for interacting with an oracle database
 """
 # -*- encoding: utf-8 -*-
 
@@ -16,7 +16,7 @@ import cx_Oracle
 # Local imports
 
 
-class PyDB:
+class OracleDB:
     """
     Class for interacting with an oracle database
     """

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -163,3 +163,16 @@ class OracleDB(DBInterface):
         :return:
         """
         return self.execute_query("SELECT 1 FROM DUAL")
+
+    def cleanup(self):
+        if self.pool is not None:
+            self.logger.info("Active session pool found. Attempting to close session pool.")
+            try:
+                self.pool.close(force=True)
+                self.logger.info("Session pool successfully closed.")
+
+            except cx_Oracle.Error as err:
+                self.logger.error("Unable to close the active session.", exc_info=True)
+                obj, = err.args
+                self.logger.error("Context:", obj.context)
+                self.logger.error("Message:", obj.message)

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -13,6 +13,8 @@ import logging
 # Third-party imports
 import cx_Oracle
 
+from pylog.pylog import get_common_logger_for_module
+
 # Local imports
 
 
@@ -21,7 +23,7 @@ class OracleDB:
     Class for interacting with an oracle database
     """
 
-    def __init__(self, oracle_config: dict, logging_format: logging.Formatter = None):
+    def __init__(self, oracle_config: dict, logging_level: int = 50, logging_format: logging.Formatter = None):
         """
         Setup for oracle db connections. oracle_config must be a python dictionary with the following fields:
         host
@@ -31,29 +33,13 @@ class OracleDB:
         pwd
 
         :param oracle_config:
-        :param logging_format:
+        :param logging_level: defaults to logging.CRITICAL
+        :param logging_format: defaults to None here, which translates to the pylog.get_commong_logging_format
         """
         self.oracle_config = oracle_config
         self.pool = self.get_session_pool()
 
-        self.logger = self.setup_logger(logging_format)
-
-    @staticmethod
-    def setup_logger(logging_format: logging.Formatter = None) -> logging.Logger:
-        logger = logging.getLogger(__name__)
-        stream_handler = logging.StreamHandler()
-        stream_handler.setLevel(logging.INFO)
-
-        if logging_format is None:
-            logging_format = logging.Formatter(
-                '{"log_level": "%(levelname)s", '
-                '"app_file_line": "%(name)s:%(lineno)d", '
-                '"message": %(message)s}'
-            )
-        stream_handler.setFormatter(logging_format)
-        logger.addHandler(stream_handler)
-        logger.setLevel(logging.INFO)
-        return logger
+        self.logger = get_common_logger_for_module(module_name=__name__, level=logging_level, log_format=logging_format)
 
     def get_session_pool(self):
         """

--- a/pydb/oracle_db.py
+++ b/pydb/oracle_db.py
@@ -50,7 +50,6 @@ class OracleDB(DBInterface):
 
         self.pool = self.set_up_session_pool()
 
-
     def set_up_session_pool(self):
         try:
             dsn_str = cx_Oracle.makedsn(self.host, self.port, service_name=self.service)

--- a/pydb/pydb.py
+++ b/pydb/pydb.py
@@ -16,7 +16,7 @@ import cx_Oracle
 # Local imports
 
 
-class DBUtil:
+class PyDB:
     """
     Class for interacting with an oracle database
     """

--- a/pydb/pydb.py
+++ b/pydb/pydb.py
@@ -22,7 +22,19 @@ class DBUtil:
     """
 
     def __init__(self, oracle_config: dict, logging_formatter: logging.Formatter = None):
+        """
+        Setup for oracle db connections. oracle_config must be a python dictionary with the following fields:
+        host
+        port
+        instance (service name)
+        user
+        pwd
+
+        :param oracle_config:
+        :param logging_formatter:
+        """
         self.oracle_config = oracle_config
+        self.pool = None
 
         self.logger = logging.getLogger(__name__)
         stream_handler = logging.StreamHandler()
@@ -44,7 +56,9 @@ class DBUtil:
         """
         Function for creating a session pool with the database
         """
-        if self.oracle_config.get('pool') is None:
+        if self.pool:
+            return self.pool
+        else:
             host = self.oracle_config.get('host')
             port = self.oracle_config.get('port')
             instance = self.oracle_config.get('instance')
@@ -61,7 +75,7 @@ class DBUtil:
                     threaded=True,
                     encoding="UTF-8"
                     )
-                self.oracle_config['pool'] = pool
+                self.pool = pool
                 return pool
 
             except cx_Oracle.DatabaseError as err:
@@ -70,8 +84,6 @@ class DBUtil:
                 self.logger.error("Context: %s", obj.context)
                 self.logger.error("Message: %s", obj.message)
                 raise Exception(f"Error creating pool: {obj.message}")
-        else:
-            return self.oracle_config['pool']
 
     def create_connection(self, pool):
         """

--- a/pydb/pydb.py
+++ b/pydb/pydb.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Module for interacting with the database
+"""
+# -*- encoding: utf-8 -*-
+
+#============================================================================================
+# Imports
+#============================================================================================
+# Standard imports
+import logging
+
+# Third-party imports
+import cx_Oracle
+
+# Local imports
+
+
+class DBUtil:
+    """
+    Class for interacting with an oracle database
+    """
+
+    def __init__(self, oracle_config: dict, logging_formatter: logging.Formatter = None):
+        self.oracle_config = oracle_config
+
+        self.logger = logging.getLogger(__name__)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(logging.INFO)
+
+        if logging_formatter:
+            stream_handler.setFormatter(logging_formatter)
+        else:
+            stream_format = logging.Formatter(
+                '{"log_level": "%(levelname)s", '
+                '"app_file_line": "%(name)s:%(lineno)d", '
+                '"message": %(message)s}'
+            )
+            stream_handler.setFormatter(stream_format)
+        self.logger.addHandler(stream_handler)
+        self.logger.setLevel(logging.INFO)
+
+    def get_session_pool(self):
+        """
+        Function for creating a session pool with the database
+        """
+        if self.oracle_config.get('pool') is None:
+            host = self.oracle_config.get('host')
+            port = self.oracle_config.get('port')
+            instance = self.oracle_config.get('instance')
+
+            try:
+                dsn_str = cx_Oracle.makedsn(host, port, service_name=instance)
+                pool = cx_Oracle.SessionPool(
+                    user=self.oracle_config.get('user'),
+                    password=self.oracle_config.get('pwd'),
+                    dsn=dsn_str,
+                    min=2,
+                    max=5,
+                    increment=1,
+                    threaded=True,
+                    encoding="UTF-8"
+                    )
+                self.oracle_config['pool'] = pool
+                return pool
+
+            except cx_Oracle.DatabaseError as err:
+                obj, = err.args
+                self.logger.error("Error creating pool")
+                self.logger.error("Context: %s", obj.context)
+                self.logger.error("Message: %s", obj.message)
+                raise Exception(f"Error creating pool: {obj.message}")
+        else:
+            return self.oracle_config['pool']
+
+    def create_connection(self, pool):
+        """
+        Function for creating a connection with the database from a session pool
+        """
+        try:
+            connection = pool.acquire()
+            return connection
+
+        except cx_Oracle.DatabaseError as err:
+            obj, = err.args
+            self.logger.error("Error acquiring database connection from the session pool")
+            self.logger.error("Context: %s", obj.context)
+            self.logger.error("Message: %s", obj.message)
+            raise Exception("Error acquiring database connection from the session pool")
+
+    @staticmethod
+    def make_dict(cursor):
+        """
+        Function for converting a query result row into a dictionary
+        """
+        column_names = [d[0] for d in cursor.description]
+
+        def create_row(*args):
+            return dict(zip(column_names, args))
+        return create_row
+
+    def execute_query(self, pool, query_string: str, args=None) -> dict:
+        """
+        Function for executing a query against the database via the session pool
+        """
+        try:
+            connection = self.create_connection(pool)
+            cursor = connection.cursor()
+            if args is not None:
+                cursor.execute(query_string, args)
+            else:
+                cursor.execute(query_string)
+            cursor.rowfactory = self.make_dict(cursor)
+            query_result = cursor.fetchall()
+            return query_result
+
+        except cx_Oracle.DatabaseError as err:
+            obj, = err.args
+            self.logger.error("Error in execute_query")
+            self.logger.error("Context: %s", obj.context)
+            self.logger.error("Message: %s", obj.message)
+            raise Exception(f"Error executing query: {query_string}")
+
+        finally:
+            cursor.close()
+            pool.release(connection)
+
+    def execute_update(self, pool, query_string, args=None):
+        """
+        Function for executing an insert/update query against the database via the session pool
+        """
+        try:
+            connection = self.create_connection(pool)
+            cursor = connection.cursor()
+            if args is not None:
+                cursor.execute(query_string, args)
+            else:
+                cursor.execute(query_string)
+            connection.commit()
+
+        except cx_Oracle.DatabaseError as err:
+            obj, = err.args
+            self.logger.error("Error in execute_update")
+            self.logger.error("Context: %s", obj.context)
+            self.logger.error("Message: %s", obj.message)
+            raise Exception(f"Error executing update: {query_string}")
+
+        finally:
+            cursor.close()
+            pool.release(connection)

--- a/pydb/sql_alchemy_oracle_db.py
+++ b/pydb/sql_alchemy_oracle_db.py
@@ -58,13 +58,16 @@ class SqlAlchemyOracleDB:
         with self.create_connection() as conn:
             return conn.scalar("select 1 from dual")
 
-    def execute_query(self, query_string: str, args: dict):
+    def execute_query(self, query_string: str, args: dict = None) -> list:
         with self.create_connection() as conn:
             statement = text(query_string)
+
             if args is not None and len(args.keys()) > 0:
-                return conn.execute(statement, args)
+                query_result = conn.execute(statement, args).fetchall()
             else:
-                return conn.execute(statement)
+                query_result = conn.execute(statement).fetchall()
+
+            return [dict(row) for row in query_result]
 
     def execute_update(self, query_string: str, args: dict):
         with self.create_connection() as conn:

--- a/pydb/sql_alchemy_oracle_db.py
+++ b/pydb/sql_alchemy_oracle_db.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from pylog.pylog import get_common_logger_for_module
 
 
-class SqlAlchemyOracleDB:
+class SqlAlchemyOracleDB(DBInterface):
     """
     Module for interacting with an Oracle DB via SQL Alchemy
     """

--- a/pydb/sql_alchemy_oracle_db.py
+++ b/pydb/sql_alchemy_oracle_db.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import sessionmaker
 
 from pylog.pylog import get_common_logger_for_module
 
+from .database import DBInterface
+
 
 class SqlAlchemyOracleDB(DBInterface):
     """

--- a/pydb/sql_alchemy_oracle_db.py
+++ b/pydb/sql_alchemy_oracle_db.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from pylog.pylog import get_common_logger_for_module
 
 
-class SqlAlchemyOracleUtil:
+class SqlAlchemyOracleDB:
     def __init__(self, host: str, port: int, service: str, user: str, pwd: str, 
                  logging_level: int = 50, logging_format: logging.Formatter = None):
         self.logger = get_common_logger_for_module(module_name=__name__, level=logging_level, log_format=logging_format)

--- a/pydb/sql_alchemy_oracle_db.py
+++ b/pydb/sql_alchemy_oracle_db.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import cx_Oracle
+import logging
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+from sqlalchemy.orm import sessionmaker
+
+from pylog.pylog import get_common_logger_for_module
+
+
+class SqlAlchemyOracleUtil:
+    def __init__(self, host: str, port: int, service: str, user: str, pwd: str, 
+                 logging_level: int = 50, logging_format: logging.Formatter = None):
+        self.logger = get_common_logger_for_module(module_name=__name__, level=logging_level, log_format=logging_format)
+        self.host = host
+        self.port = port
+        self.service = service
+        self.user = user
+        self.pwd = pwd
+        self.engine = self.setup_engine()
+
+    def setup_engine(self):
+        try:
+            dsn_str = cx_Oracle.makedsn(self.host, self.port, service_name=self.service)
+            pool = cx_Oracle.SessionPool(
+                user=self.user, password=self.pwd, dsn=dsn_str,
+                min=2, max=5, increment=1, threaded=True
+            )
+            engine = create_engine("oracle://",
+                                   creator=pool.acquire,
+                                   poolclass=NullPool,
+                                   echo=True,
+                                   max_identifier_length=128)
+
+            self.logger.info("Setup sqlalchemy engine successfully")
+            return engine
+        except Exception as err:
+            obj, = err.args
+            self.logger.critical("Cannot create sql alchemy engine")
+            self.logger.error("Context: %s", obj.context)
+            self.logger.error("Message: %s", obj.message)
+            raise Exception(f"Cannot create sql alchemy engine: {obj.message}")
+
+    def get_engine(self):
+        if self.engine is None:
+            self.engine = self.setup_engine()
+        return self.engine
+
+    def get_session(self):
+        Session = sessionmaker(bind=self.get_engine())
+        return Session()
+
+    def create_connection(self):
+        return self.engine.connect()
+
+    def health_check(self):
+        with self.create_connection() as conn:
+            return conn.scalar("select 1 from dual")
+
+    def execute_query(self, query_string: str, args: dict):
+        with self.create_connection() as conn:
+            statement = text(query_string)
+            if args is not None and len(args.keys()) > 0:
+                return conn.execute(statement, args)
+            else:
+                return conn.execute(statement)
+
+    def execute_update(self, query_string: str, args: dict):
+        with self.create_connection() as conn:
+            statement = text(query_string)
+            trans = conn.begin()
+            if args is not None and len(args.keys()) > 0:
+                conn.execute(statement, args)
+            else:
+                conn.execute(statement)
+            trans.commit()
+
+    def cleanup(self):
+        if self.engine is not None:
+            self.logger.info("sql alchemy engine found")
+            try:
+                self.engine.dispose()
+            except Exception as err:
+                obj, = err.args
+                self.logger.critical("Cannot dispose sql alchemy engine")
+                self.logger.error("Context: %s", obj.context)
+                self.logger.error("Message: %s", obj.message)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pydb",
-    version="0.0.1",
+    version="0.0.2",
     author="Michael Kerry",
     author_email="michael_kerry@harvard.edu",
     description="A package to facilitate connecting to an oracle DB from a python application",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     install_requires=[
         "cx-Oracle==8.1.0",
         'sqlalchemy==1.4.1',
-        'pylog @ https://github.com/huit/pylog/archive/v0.0.2.tar.gz#egg=pylog',
+        'pylog @ https://github.com/huit/pylog/archive/refs/tags/v0.0.2.tar.gz#egg=pylog',
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     ],
     install_requires=[
         "cx-Oracle==8.1.0",
+        'pylog @ https://github.com/huit/pylog/archive/v0.0.1.tar.gz#egg=pylog',
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     ],
     install_requires=[
         "cx-Oracle==8.1.0",
+        'sqlalchemy==1.4.1',
         'pylog @ https://github.com/huit/pylog/archive/v0.0.1.tar.gz#egg=pylog',
     ],
     packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="pydb",
+    version="0.0.1",
+    author="Michael Kerry",
+    author_email="michael_kerry@harvard.edu",
+    description="A package to facilitate connecting to an oracle DB from a python application",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/huit/pydb",
+    project_urls={
+        "Bug Tracker": "https://github.com/huit/pydb/issues",
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        "cx-Oracle==8.1.0",
+    ],
+    packages=setuptools.find_packages(),
+    python_requires=">=3.7",
+)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     install_requires=[
         "cx-Oracle==8.1.0",
         'sqlalchemy==1.4.1',
-        'pylog @ https://github.com/huit/pylog/archive/v0.0.1.tar.gz#egg=pylog',
+        'pylog @ https://github.com/huit/pylog/archive/v0.0.2.tar.gz#egg=pylog',
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.7",


### PR DESCRIPTION
The idea here is to provide a pluggable collection of utils to enable easy interactions with databases of various types.

I've started with oracle db bc the example project into which this package is integrated (a flask api example project) uses an oracle db, but the intent is to enable additional modules for mysql, postgres, etc.

I've updated the documentation in a way that I think makes sense - I was able to start a python console session and follow those instructions (with valid connection information) and pull back results. Please let me know what else might be helpful. One section to be added at beginning: 'Purpose and Intended Audience'